### PR TITLE
Add asset handlers

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -57,6 +57,9 @@ const patternlab_module = function(config) {
   const patternlab = new PatternLab(config);
   const paths = patternlab.config.paths;
 
+  // Should this be moved into ./lib/patternlab.js?
+  const assetHandlers = {};
+
   function help() {
     logger.info('');
 
@@ -369,7 +372,7 @@ const patternlab_module = function(config) {
       patternlab.isBusy = true;
       return buildPatterns(options.cleanPublic, options.data).then(() => {
         return new ui_builder().buildFrontend(patternlab).then(() => {
-          copier()
+          copier(assetHandlers)
             .copyAndWatch(patternlab.config.paths, patternlab, options)
             .then(() => {
               this.events.once(events.PATTERNLAB_PATTERN_CHANGE, () => {
@@ -490,6 +493,11 @@ const patternlab_module = function(config) {
     },
 
     events: patternlab.events,
+
+    assetHandler: function(key, handler) {
+      // Should this be moved into ./lib/patternlab.js?
+      assetHandlers[key] = handler;
+    },
   };
 };
 

--- a/core/lib/changes_hunter.js
+++ b/core/lib/changes_hunter.js
@@ -75,7 +75,7 @@ ChangesHunter.prototype = {
    * @param {string} file
    */
   checkLastModified: function(currentPattern, file) {
-    if (file && fs.pathExistsSync(file)) {
+    if (file && fs.existsSync(file)) {
       try {
         const stat = fs.statSync(file);
 

--- a/core/lib/copier.js
+++ b/core/lib/copier.js
@@ -7,7 +7,7 @@ const copyFile = require('./copyFile');
 const watchAssets = require('./watchAssets');
 const watchPatternLabFiles = require('./watchPatternLabFiles');
 
-const copier = () => {
+const copier = assetHandlers => {
   const transform_paths = directories => {
     //create array with all source keys minus our blacklist
     const dirs = {};
@@ -60,9 +60,18 @@ const copier = () => {
     _.each(dirs, (dir, key) => {
       //if we want to watch files, do so, otherwise just copy each file
       if (options.watch) {
-        watchAssets(patternlab, basePath, dir, key, copyOptions);
+        watchAssets(
+          patternlab,
+          basePath,
+          dir,
+          key,
+          copyOptions,
+          false,
+          assetHandlers[key]
+        );
       } else {
         //just copy
+        // TODO: A non-watched build should also use assetHandlers
         const destination = path.resolve(basePath, dir.public);
         copyPromises.push(copyFile(dir.source, destination, copyOptions));
       }

--- a/test/changes_hunter_tests.js
+++ b/test/changes_hunter_tests.js
@@ -15,7 +15,7 @@ const fsMock = {
       },
     };
   },
-  pathExistsSync: () => {
+  existsSync: () => {
     return true;
   },
 };


### PR DESCRIPTION
Proof of concept: Customer asset handlers (i.e. custom alternative to copyFile).

# Background 
PL does not (and should not, IMO) handle manipulation of assets (like SCSS, for example). Right now the way to use SCSS together with PL is to output the CSS into `./sources/*` and let PL copy the files from there to `./public/`. 

# Asset handlers
An asset handler function replaces PL's internal file copier `copyFile`. Why would you want to do this?

* Piggyback on PL's file watcher (less work)
* Avoid unnecessary writing to disk (i.e. gain speed)
* When updating from PL 2 (Gulp edition) to PL 3 (core), it was confusing to me how I would migrate my SCSS build. A solution similar to this would have made it more intuitive to me personally. 

To add an asset handler: 

```JavaScript
const assetHandler = ([...attributes]) => {
  // Manipulate files appropriately. 
  // E.g. when _some-include.scss is saved I can re-build styles.scss
};

// Tell PL to run asset handler when dealing with my 'scss' assets, which I've added to my config
patternlab.assetHandler('scss', assetHandler); 
```

# Shortcomings
I place SCSS files alongside my Markdown, JSON and Mustache files. Originally I wanted to use the PL watcher to re-build my CSS without adding another watcher. However, with this code I still have to watch the directory twice in my config: 

```JSON
"source" : {
    "patterns" : "./source/_patterns/",
    "scss": "./source/_patterns/"
},
"public": {
    "scss" : "./public/css",
    ...
},
...
```
